### PR TITLE
Remove vite/modulepreload-polyfill import from root_vue.js

### DIFF
--- a/bcfms/media/js/views/root_vue.js
+++ b/bcfms/media/js/views/root_vue.js
@@ -1,5 +1,4 @@
 // // add the beginning of your app entry
-import 'vite/modulepreload-polyfill';
 import { createRouter, createWebHistory } from 'vue-router';
 import BCFMSApp from '@/bcfms/App.vue';
 import { routes } from '@/bcfms/routes.ts';

--- a/bcfms/src/root_vue.js
+++ b/bcfms/src/root_vue.js
@@ -1,5 +1,4 @@
 // // add the beginning of your app entry
-import 'vite/modulepreload-polyfill';
 import { createRouter, createWebHistory } from 'vue-router';
 import BCFMSApp from '@/bcfms/App.vue';
 import { routes } from '@/bcfms/routes.ts';


### PR DESCRIPTION
This PR removes the vite/modulepreload-polyfill import from root_vue.js in order to fix build issues.

closes #43