### PR TITLE
'Other Project Type' should only be visible if 'Other' is selected

### DIFF
--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step3_Type.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step3_Type.vue
@@ -61,6 +61,10 @@ defineExpose({ isValid });
             name="otherProjectType"
         >
             <LabelledInput
+                v-if="
+                    ipa.projectDetails.projectType ===
+                    '54722cfa-61f7-41e9-9e02-5b676e3bcc3e'
+                "
                 label="Other Project Type"
                 hint="Enter a brief project type"
                 input-name="otherProjectType"


### PR DESCRIPTION
This PR hides the 'Other Project Type' input field unless 'Project Type' is 'Other'.