### PR TITLE
Fix error 'Property 'projectDetails' does not exist on type 'typeo…

### DIFF
--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step2_Details.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step2_Details.vue
@@ -14,7 +14,12 @@ import type { IPA } from '@/bcfms/ipa/schema/IPASchema.ts';
 import { ProjectDetailsSchema } from '@/bcfms/ipa/schema/ProjectDetailsSchema.ts';
 import { DATE_FORMAT } from '@/bcfms/constants.ts';
 
-const ipa: typeof IPA = inject('ipa') as typeof IPA;
+const ipa = inject<IPA>('ipa');
+
+if (!ipa) {
+    throw new Error('IPA instance not provided.');
+}
+
 const projectDetailsForm: Ref<FormInstance | null> = useTemplateRef(
     'projectDetailsForm',
 ) as Ref<FormInstance | null>;
@@ -90,6 +95,7 @@ defineExpose({ isValid });
                     :required="true"
                 >
                     <ResourceInstanceSelectWidget
+                        v-model="ipa.projectDetails.projectInitiator"
                         :mode="EDIT"
                         :initial-value="null"
                         graph-slug="project_assessment"

--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step3_Type.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step3_Type.vue
@@ -10,7 +10,12 @@ import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/Concep
 import type { IPA } from '@/bcfms/ipa/schema/IPASchema.ts';
 import { ProjectDetailsSchema } from '@/bcfms/ipa/schema/ProjectDetailsSchema.ts';
 
-const ipa: typeof IPA = inject('ipa') as typeof IPA;
+const ipa = inject<IPA>('ipa');
+
+if (!ipa) {
+    throw new Error('IPA instance not provided.');
+}
+
 const projectTypeForm: Ref<FormInstance | null> = useTemplateRef(
     'projectTypeForm',
 ) as Ref<FormInstance | null>;

--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step4_Location.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step4_Location.vue
@@ -10,7 +10,12 @@ import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/Concep
 import type { IPA } from '@/bcfms/ipa/schema/IPASchema.ts';
 import { ProjectDetailsSchema } from '@/bcfms/ipa/schema/ProjectDetailsSchema.ts';
 
-const ipa: typeof IPA = inject('ipa') as typeof IPA;
+const ipa = inject<IPA>('ipa');
+
+if (!ipa) {
+    throw new Error('IPA instance not provided.');
+}
+
 const projectLocationForm: Ref<FormInstance | null> = useTemplateRef(
     'projectLocationForm',
 ) as Ref<FormInstance | null>;

--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step6_ReviewSubmission.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step6_ReviewSubmission.vue
@@ -2,7 +2,7 @@
 import { inject } from 'vue';
 import type { IPA } from '@/bcfms/ipa/schema/IPASchema.ts';
 
-const ipa: typeof IPA = inject('ipa') as typeof IPA;
+const ipa = inject<IPA>('ipa');
 </script>
 
 <template>
@@ -15,40 +15,40 @@ const ipa: typeof IPA = inject('ipa') as typeof IPA;
     <div class="div-grid-cols">
         <div>Submission Date</div>
         <div>
-            {{ ipa.projectDetails.projectStartDate }}
+            {{ ipa?.projectDetails.projectStartDate }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Project Name</div>
         <div>
-            {{ ipa.projectDetails.projectName }}
+            {{ ipa?.projectDetails.projectName }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Initiator</div>
         <div>
-            {{ ipa.projectDetails.projectInitiator }}
+            {{ ipa?.projectDetails.projectInitiator }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Industry Company / Individual / Organization</div>
         <div>
-            {{ ipa.projectDetails.industryCompanyName }}
+            {{ ipa?.projectDetails.industryCompanyName }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Authorizing Agency</div>
         <div>
-            {{ ipa.projectDetails.projectAuthorizingAgency }}
+            {{ ipa?.projectDetails.projectAuthorizingAgency }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Estimated Project Start / End Dates</div>
         <div>
-            {{ ipa.projectDetails.projectStartDate }} -
+            {{ ipa?.projectDetails.projectStartDate }} -
             {{
-                ipa.projectDetails.projectEndDate
-                    ? ipa.projectDetails.projectEndDate
+                ipa?.projectDetails.projectEndDate
+                    ? ipa?.projectDetails.projectEndDate
                     : ''
             }}
         </div>
@@ -56,19 +56,19 @@ const ipa: typeof IPA = inject('ipa') as typeof IPA;
     <div class="div-grid-cols">
         <div>Project Type</div>
         <div>
-            {{ ipa.projectDetails.projectType }}
+            {{ ipa?.projectDetails.projectType }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Proposed Activity</div>
         <div>
-            {{ ipa.projectDetails.proposedActivity }}
+            {{ ipa?.projectDetails.proposedActivity }}
         </div>
     </div>
     <div class="div-grid-cols">
         <div>Location Description</div>
         <div>
-            {{ ipa.projectDetails.locationDescription }}
+            {{ ipa?.projectDetails.locationDescription }}
         </div>
     </div>
     <div class="div-grid-cols">

--- a/bcfms/src/bcfms/ipa/schema/IPASchema.ts
+++ b/bcfms/src/bcfms/ipa/schema/IPASchema.ts
@@ -20,8 +20,8 @@ class IPA implements IPAType {
         this.projectDetails = {};
         this.initialProjectReview = {};
     }
-    projectDetails: object;
-    initialProjectReview: object;
+    projectDetails: typeof ProjectDetailsSchema;
+    initialProjectReview: typeof InitialProjectReviewSchema;
 }
 
 console.log(requiredIPASchema);


### PR DESCRIPTION
This PR fixes the error 'Property 'projectDetails' does not exist on type 'typeof IPA'.' which occurred on Steps 2-4, and Step 6. This occurred because because properties were accessed on the class constructor, not on the instance itself.