### PR TITLE
Import arches common css at top workflow level

### DIFF
--- a/bcfms/src/bcfms/ipa/pages/ReviewProject/ReviewProject.vue
+++ b/bcfms/src/bcfms/ipa/pages/ReviewProject/ReviewProject.vue
@@ -209,6 +209,9 @@ onMounted(() => {
     </Panel>
 </template>
 
+<style>
+@import url('@/bcgov_arches_common/css/arches_common.css');
+</style>
 <style scoped>
 .dashboard-card {
     font-size: 1.1rem;

--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/SubmitProject.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/SubmitProject.vue
@@ -287,6 +287,10 @@ onMounted(() => {
     </Panel>
 </template>
 
+<style>
+@import url('@/bcgov_arches_common/css/arches_common.css');
+</style>
+
 <style scoped>
 .dashboard-card {
     font-size: 1.1rem;

--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step2_Details.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step2_Details.vue
@@ -12,7 +12,6 @@ import { zodResolver } from '@primevue/forms/resolvers/zod';
 import DateWidget from '@/arches_component_lab/widgets/DateWidget/DateWidget.vue';
 import type { IPA } from '@/bcfms/ipa/schema/IPASchema.ts';
 import { ProjectDetailsSchema } from '@/bcfms/ipa/schema/ProjectDetailsSchema.ts';
-import { DATE_FORMAT } from '@/bcfms/constants.ts';
 
 const ipa = inject<IPA>('ipa');
 
@@ -204,8 +203,6 @@ defineExpose({ isValid });
 </template>
 
 <style>
-@import url('node_modules/bcgov_arches_common/bcgov_arches_common/css/arches_common.css');
-
 .inline-block {
     display: inline-block;
     width: unset;

--- a/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step6_ReviewSubmission.vue
+++ b/bcfms/src/bcfms/ipa/pages/SubmitProject/steps/Step6_ReviewSubmission.vue
@@ -19,7 +19,6 @@ const ipa = inject<IPA>('ipa');
         </div>
     </div>
     <div class="div-grid-cols">
-
         <div>Project Name</div>
         <div>
             {{ ipa?.projectDetails.projectName }}

--- a/bcfms/src/bcfms/routes.ts
+++ b/bcfms/src/bcfms/routes.ts
@@ -43,7 +43,6 @@ const routeNames: BCFMSRouteNamesType = {
     login: 'login',
     submitProject: 'submitProject',
     reviewProject: 'reviewProject',
-
 };
 
 export { routes, routeNames };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bcfms",
-    "version": "1.2.0",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bcfms",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@ckeditor/ckeditor5-vue": "7.3.0",
@@ -14,9 +14,9 @@
                 "@primevue/forms": "^4.3.5",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vue/cli": "^5.0.8",
-                "arches": "github:bcgov/arches#stable/7.6.12_bcgov",
+                "arches": "github:bcgov/arches#v7.6.12.1_bcgov",
                 "arches-component-lab": "github:archesproject/arches-component-lab#main",
-                "bcgov_arches_common": "file:../arches_common",
+                "bcgov_arches_common": "github:bcgov/bcgov-arches-common#v1.2.4",
                 "ckeditor5": "44.2.0",
                 "js-cookie": "^2.1.1",
                 "primevue": "^4.3.4",
@@ -47,22 +47,6 @@
                 "vite-plugin-css-injected-by-js": "^3.5.2",
                 "vite-plugin-node-polyfills": "^0.23.0",
                 "vue-eslint-parser": "^9.4.3"
-            }
-        },
-        "../arches_common": {
-            "name": "bcgov_arches_common",
-            "version": "1.2.0a1",
-            "license": "AGPL-3.0-only",
-            "dependencies": {
-                "arches": "bcgov/arches#stable/7.6.12_bcgov",
-                "primevue": "^4.2.5",
-                "vite": "latest",
-                "vue-router": "^4.4.3"
-            },
-            "devDependencies": {
-                "@vue/eslint-config-prettier": "^10.2.0",
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.12",
-                "eslint-plugin-prettier": "^5.2.3"
             }
         },
         "node_modules/@achrinza/node-ipc": {
@@ -1627,9 +1611,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
-            "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
+            "version": "7.28.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+            "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
@@ -2174,9 +2158,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-            "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+            "version": "7.28.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+            "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -3189,9 +3173,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-            "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.7.tgz",
+            "integrity": "sha512-uD0kKFHh6ETr8TqEtaAcV+dn/2qnYbH/+8wGEdY70Qf7l1l/jmBUbrmQqwiPKAQE6cOQ7dTj6Xr0HzQDGHyceQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -3205,9 +3189,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-            "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.7.tgz",
+            "integrity": "sha512-Jhuet0g1k9rAJHrXGIh7sFknFuT4sfytYZpZpuZl7YKDhnPByVAm5oy2LEBmMbuYf3ejWVYCc2seX81Mk+madA==",
             "cpu": [
                 "arm"
             ],
@@ -3221,9 +3205,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-            "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.7.tgz",
+            "integrity": "sha512-p0ohDnwyIbAtztHTNUTzN5EGD/HJLs1bwysrOPgSdlIA6NDnReoVfoCyxG6W1d85jr2X80Uq5KHftyYgaK9LPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3237,9 +3221,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-            "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.7.tgz",
+            "integrity": "sha512-mMxIJFlSgVK23HSsII3ZX9T2xKrBCDGyk0qiZnIW10LLFFtZLkFD6imZHu7gUo2wkNZwS9Yj3mOtZD3ZPcjCcw==",
             "cpu": [
                 "x64"
             ],
@@ -3253,9 +3237,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-            "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.7.tgz",
+            "integrity": "sha512-jyOFLGP2WwRwxM8F1VpP6gcdIJc8jq2CUrURbbTouJoRO7XCkU8GdnTDFIHdcifVBT45cJlOYsZ1kSlfbKjYUQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3269,9 +3253,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-            "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.7.tgz",
+            "integrity": "sha512-m9bVWqZCwQ1BthruifvG64hG03zzz9gE2r/vYAhztBna1/+qXiHyP9WgnyZqHgGeXoimJPhAmxfbeU+nMng6ZA==",
             "cpu": [
                 "x64"
             ],
@@ -3285,9 +3269,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.7.tgz",
+            "integrity": "sha512-Bss7P4r6uhr3kDzRjPNEnTm/oIBdTPRNQuwaEFWT/uvt6A1YzK/yn5kcx5ZxZ9swOga7LqeYlu7bDIpDoS01bA==",
             "cpu": [
                 "arm64"
             ],
@@ -3301,9 +3285,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-            "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.7.tgz",
+            "integrity": "sha512-S3BFyjW81LXG7Vqmr37ddbThrm3A84yE7ey/ERBlK9dIiaWgrjRlre3pbG7txh1Uaxz8N7wGGQXmC9zV+LIpBQ==",
             "cpu": [
                 "x64"
             ],
@@ -3317,9 +3301,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-            "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.7.tgz",
+            "integrity": "sha512-JZMIci/1m5vfQuhKoFXogCKVYVfYQmoZJg8vSIMR4TUXbF+0aNlfXH3DGFEFMElT8hOTUF5hisdZhnrZO/bkDw==",
             "cpu": [
                 "arm"
             ],
@@ -3333,9 +3317,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-            "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.7.tgz",
+            "integrity": "sha512-HfQZQqrNOfS1Okn7PcsGUqHymL1cWGBslf78dGvtrj8q7cN3FkapFgNA4l/a5lXDwr7BqP2BSO6mz9UremNPbg==",
             "cpu": [
                 "arm64"
             ],
@@ -3349,9 +3333,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-            "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.7.tgz",
+            "integrity": "sha512-9Jex4uVpdeofiDxnwHRgen+j6398JlX4/6SCbbEFEXN7oMO2p0ueLN+e+9DdsdPLUdqns607HmzEFnxwr7+5wQ==",
             "cpu": [
                 "ia32"
             ],
@@ -3365,9 +3349,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-            "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.7.tgz",
+            "integrity": "sha512-TG1KJqjBlN9IHQjKVUYDB0/mUGgokfhhatlay8aZ/MSORMubEvj/J1CL8YGY4EBcln4z7rKFbsH+HeAv0d471w==",
             "cpu": [
                 "loong64"
             ],
@@ -3381,9 +3365,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-            "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.7.tgz",
+            "integrity": "sha512-Ty9Hj/lx7ikTnhOfaP7ipEm/ICcBv94i/6/WDg0OZ3BPBHhChsUbQancoWYSO0WNkEiSW5Do4febTTy4x1qYQQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -3397,9 +3381,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-            "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.7.tgz",
+            "integrity": "sha512-MrOjirGQWGReJl3BNQ58BLhUBPpWABnKrnq8Q/vZWWwAB1wuLXOIxS2JQ1LT3+5T+3jfPh0tyf5CpbyQHqnWIQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -3413,9 +3397,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-            "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.7.tgz",
+            "integrity": "sha512-9pr23/pqzyqIZEZmQXnFyqp3vpa+KBk5TotfkzGMqpw089PGm0AIowkUppHB9derQzqniGn3wVXgck19+oqiOw==",
             "cpu": [
                 "riscv64"
             ],
@@ -3429,9 +3413,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-            "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.7.tgz",
+            "integrity": "sha512-4dP11UVGh9O6Y47m8YvW8eoA3r8qL2toVZUbBKyGta8j6zdw1cn9F/Rt59/Mhv0OgY68pHIMjGXWOUaykCnx+w==",
             "cpu": [
                 "s390x"
             ],
@@ -3445,9 +3429,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-            "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.7.tgz",
+            "integrity": "sha512-ghJMAJTdw/0uhz7e7YnpdX1xVn7VqA0GrWrAO2qKMuqbvgHT2VZiBv1BQ//VcHsPir4wsL3P2oPggfKPzTKoCA==",
             "cpu": [
                 "x64"
             ],
@@ -3461,9 +3445,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.7.tgz",
+            "integrity": "sha512-bwXGEU4ua45+u5Ci/a55B85KWaDSRS8NPOHtxy2e3etDjbz23wlry37Ffzapz69JAGGc4089TBo+dGzydQmydg==",
             "cpu": [
                 "arm64"
             ],
@@ -3477,9 +3461,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-            "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.7.tgz",
+            "integrity": "sha512-tUZRvLtgLE5OyN46sPSYlgmHoBS5bx2URSrgZdW1L1teWPYVmXh+QN/sKDqkzBo/IHGcKcHLKDhBeVVkO7teEA==",
             "cpu": [
                 "x64"
             ],
@@ -3493,9 +3477,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.7.tgz",
+            "integrity": "sha512-bTJ50aoC+WDlDGBReWYiObpYvQfMjBNlKztqoNUL0iUkYtwLkBQQeEsTq/I1KyjsKA5tyov6VZaPb8UdD6ci6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3509,9 +3493,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-            "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.7.tgz",
+            "integrity": "sha512-TA9XfJrgzAipFUU895jd9j2SyDh9bbNkK2I0gHcvqb/o84UeQkBpi/XmYX3cO1q/9hZokdcDqQxIi6uLVrikxg==",
             "cpu": [
                 "x64"
             ],
@@ -3524,10 +3508,26 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.7.tgz",
+            "integrity": "sha512-5VTtExUrWwHHEUZ/N+rPlHDwVFQ5aME7vRJES8+iQ0xC/bMYckfJ0l2n3yGIfRoXcK/wq4oXSItZAz5wslTKGw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-            "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.7.tgz",
+            "integrity": "sha512-umkbn7KTxsexhv2vuuJmj9kggd4AEtL32KodkJgfhNOHMPtQ55RexsaSrMb+0+jp9XL4I4o2y91PZauVN4cH3A==",
             "cpu": [
                 "x64"
             ],
@@ -3541,9 +3541,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-            "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.7.tgz",
+            "integrity": "sha512-j20JQGP/gz8QDgzl5No5Gr4F6hurAZvtkFxAKhiv2X49yi/ih8ECK4Y35YnjlMogSKJk931iNMcd35BtZ4ghfw==",
             "cpu": [
                 "arm64"
             ],
@@ -3557,9 +3557,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-            "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.7.tgz",
+            "integrity": "sha512-4qZ6NUfoiiKZfLAXRsvFkA0hoWVM+1y2bSHXHkpdLAs/+r0LgwqYohmfZCi985c6JWHhiXP30mgZawn/XrqAkQ==",
             "cpu": [
                 "ia32"
             ],
@@ -3573,9 +3573,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-            "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.7.tgz",
+            "integrity": "sha512-FaPsAHTwm+1Gfvn37Eg3E5HIpfR3i6x1AIcla/MkqAIupD4BW3MrSeUqfoTzwwJhk3WE2/KqUn4/eenEJC76VA==",
             "cpu": [
                 "x64"
             ],
@@ -3680,9 +3680,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-            "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3754,9 +3754,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.30.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-            "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+            "version": "9.31.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+            "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3785,19 +3785,6 @@
             "dependencies": {
                 "@eslint/core": "^0.15.1",
                 "levn": "^0.4.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/json-schema": "^7.0.15"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4734,13 +4721,13 @@
             }
         },
         "node_modules/@pkgr/core": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
-            "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.4.tgz",
+            "integrity": "sha512-MrfbnMgfKexic6mxC4xrSBVQHSvmvhz7qtSDG5cHg4xn8kHXkPltUY44R5u4ghYf+1rXpOvC2drbMcE1rZ3a2A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+                "node": "^14.18.0 || >=16.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/pkgr"
@@ -5008,9 +4995,9 @@
             }
         },
         "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5021,9 +5008,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
-            "integrity": "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
+            "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
             "cpu": [
                 "arm"
             ],
@@ -5034,9 +5021,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz",
-            "integrity": "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
+            "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5047,9 +5034,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz",
-            "integrity": "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
+            "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
             "cpu": [
                 "arm64"
             ],
@@ -5060,9 +5047,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz",
-            "integrity": "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
+            "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
             "cpu": [
                 "x64"
             ],
@@ -5073,9 +5060,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz",
-            "integrity": "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
+            "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
             "cpu": [
                 "arm64"
             ],
@@ -5086,9 +5073,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz",
-            "integrity": "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
+            "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
             "cpu": [
                 "x64"
             ],
@@ -5099,9 +5086,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz",
-            "integrity": "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
+            "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
             "cpu": [
                 "arm"
             ],
@@ -5112,9 +5099,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz",
-            "integrity": "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
+            "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
             "cpu": [
                 "arm"
             ],
@@ -5125,9 +5112,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz",
-            "integrity": "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
+            "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
             "cpu": [
                 "arm64"
             ],
@@ -5138,9 +5125,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz",
-            "integrity": "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
+            "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
             "cpu": [
                 "arm64"
             ],
@@ -5151,9 +5138,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz",
-            "integrity": "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
+            "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
             "cpu": [
                 "loong64"
             ],
@@ -5164,9 +5151,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz",
-            "integrity": "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
+            "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
             "cpu": [
                 "ppc64"
             ],
@@ -5177,9 +5164,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz",
-            "integrity": "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
+            "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
             "cpu": [
                 "riscv64"
             ],
@@ -5190,9 +5177,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz",
-            "integrity": "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
+            "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
             "cpu": [
                 "riscv64"
             ],
@@ -5203,9 +5190,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz",
-            "integrity": "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
+            "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
             "cpu": [
                 "s390x"
             ],
@@ -5216,9 +5203,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
-            "integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
+            "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
             "cpu": [
                 "x64"
             ],
@@ -5229,9 +5216,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz",
-            "integrity": "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
+            "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
             "cpu": [
                 "x64"
             ],
@@ -5242,9 +5229,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz",
-            "integrity": "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
+            "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
             "cpu": [
                 "arm64"
             ],
@@ -5255,9 +5242,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz",
-            "integrity": "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
+            "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
             "cpu": [
                 "ia32"
             ],
@@ -5268,9 +5255,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
-            "integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
+            "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
             "cpu": [
                 "x64"
             ],
@@ -7346,18 +7333,18 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.0.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-            "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+            "version": "24.0.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+            "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.8.0"
             }
         },
         "node_modules/@types/node-forge": {
-            "version": "1.3.12",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.12.tgz",
-            "integrity": "sha512-a0ToKlRVnUw3aXKQq2F+krxZKq7B8LEQijzPn5RdFAMatARD2JX9o8FBpMXOOrjob0uc13aN+V/AXniOXW4d9A==",
+            "version": "1.3.13",
+            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.13.tgz",
+            "integrity": "sha512-zePQJSW5QkwSHKRApqWCVKeKoSOt4xvEnLENZPjyvm9Ezdf/EyDeJM7jqLzOwjVICQQzvLZ63T55MKdJB5H6ww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7494,17 +7481,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
-            "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.37.0.tgz",
+            "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.35.1",
-                "@typescript-eslint/type-utils": "8.35.1",
-                "@typescript-eslint/utils": "8.35.1",
-                "@typescript-eslint/visitor-keys": "8.35.1",
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/type-utils": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -7518,7 +7505,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.35.1",
+                "@typescript-eslint/parser": "^8.37.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
             }
@@ -7534,16 +7521,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
-            "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.37.0.tgz",
+            "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.35.1",
-                "@typescript-eslint/types": "8.35.1",
-                "@typescript-eslint/typescript-estree": "8.35.1",
-                "@typescript-eslint/visitor-keys": "8.35.1",
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -7559,14 +7546,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
-            "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.37.0.tgz",
+            "integrity": "sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.35.1",
-                "@typescript-eslint/types": "^8.35.1",
+                "@typescript-eslint/tsconfig-utils": "^8.37.0",
+                "@typescript-eslint/types": "^8.37.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -7581,14 +7568,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
-            "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.37.0.tgz",
+            "integrity": "sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.35.1",
-                "@typescript-eslint/visitor-keys": "8.35.1"
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7599,9 +7586,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
-            "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.37.0.tgz",
+            "integrity": "sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7616,14 +7603,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
-            "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.37.0.tgz",
+            "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.35.1",
-                "@typescript-eslint/utils": "8.35.1",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -7640,9 +7628,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
-            "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
+            "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7654,16 +7642,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
-            "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.37.0.tgz",
+            "integrity": "sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.35.1",
-                "@typescript-eslint/tsconfig-utils": "8.35.1",
-                "@typescript-eslint/types": "8.35.1",
-                "@typescript-eslint/visitor-keys": "8.35.1",
+                "@typescript-eslint/project-service": "8.37.0",
+                "@typescript-eslint/tsconfig-utils": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -7683,16 +7671,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
-            "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.37.0.tgz",
+            "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.35.1",
-                "@typescript-eslint/types": "8.35.1",
-                "@typescript-eslint/typescript-estree": "8.35.1"
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7707,13 +7695,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
-            "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.37.0.tgz",
+            "integrity": "sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.35.1",
+                "@typescript-eslint/types": "8.37.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -8605,6 +8593,19 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
+            }
+        },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -8629,9 +8630,9 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9080,7 +9081,7 @@
         },
         "node_modules/arches-component-lab": {
             "name": "arches_component_lab",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#d79a0857eda2d8b46627667dfbbc677bb97b011f",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#7390be59da2bab199a72c058ba2b9d12cc898bf8",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@primevue/forms": "4.3.3",
@@ -9119,6 +9120,15 @@
             },
             "engines": {
                 "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches-component-lab/node_modules/@primeuix/styles": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-1.0.3.tgz",
+            "integrity": "sha512-yHj/Q+fosJ1736Ty5lRbpqhKa9piou+xZPPppNHUDshq0+XhrFwDGggvPGmDAJyUIM+ChM/Nj8lPY/AwTNXAkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.5.1"
             }
         },
         "node_modules/arches-component-lab/node_modules/@primeuix/themes": {
@@ -9183,8 +9193,8 @@
             }
         },
         "node_modules/arches-component-lab/node_modules/arches": {
-            "version": "8.0.1",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#d0eff3959d934517231f92654aa7a54dedaa431a",
+            "version": "8.0.2",
+            "resolved": "git+ssh://git@github.com/archesproject/arches.git#ccf86172034609eccce67e8c0efc0555f15f8867",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
@@ -9192,6 +9202,7 @@
                 "@mapbox/geojsonhint": "3.3.0",
                 "@mapbox/mapbox-gl-draw": "1.4.3",
                 "@mapbox/mapbox-gl-geocoder": "4.7.4",
+                "@primeuix/styles": "1.0.3",
                 "@primeuix/themes": "1.0.1",
                 "@tmcw/togeojson": "^4.3.0",
                 "@turf/turf": "^6.5.0",
@@ -9894,8 +9905,16 @@
             "license": "MIT"
         },
         "node_modules/bcgov_arches_common": {
-            "resolved": "../arches_common",
-            "link": true
+            "name": "bcgov-arches-common",
+            "version": "1.2.4",
+            "resolved": "git+ssh://git@github.com/bcgov/bcgov-arches-common.git#b1bf448932604e739ca45e85354a79dac41f46c5",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "arches": "bcgov/arches#v7.6.12.1_bcgov",
+                "primevue": "^4.2.5",
+                "vite": "latest",
+                "vue-router": "^4.4.3"
+            }
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -10356,9 +10375,9 @@
             }
         },
         "node_modules/cacheable": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.1.tgz",
-            "integrity": "sha512-Fa2BZY0CS9F0PFc/6aVA6tgpOdw+hmv9dkZOlHXII5v5Hw+meJBIWDcPrG9q/dXxGcNbym5t77fzmawrBQfTmQ==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.2.tgz",
+            "integrity": "sha512-hMkETCRV4hwBAvjQY1/xGw15tlPj+7cM4d5HOlYJJFftLQVRCboVX+mT6AJ6eL0fsqUhSUwDiF+pgfTR2r2Hxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10533,9 +10552,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001726",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-            "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+            "version": "1.0.30001727",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -11109,9 +11128,9 @@
             }
         },
         "node_modules/compression": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-            "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11119,7 +11138,7 @@
                 "compressible": "~2.0.18",
                 "debug": "2.6.9",
                 "negotiator": "~0.6.4",
-                "on-headers": "~1.0.2",
+                "on-headers": "~1.1.0",
                 "safe-buffer": "5.2.1",
                 "vary": "~1.1.2"
             },
@@ -11176,24 +11195,30 @@
             }
         },
         "node_modules/concaveman": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
-            "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-2.0.0.tgz",
+            "integrity": "sha512-3a9C//4G44/boNehBPZMRh8XxrwBvTXlhENUim+GMm207WoDie/Vq89U5lkhLn3kKA+vxwmwfdQPWIRwjQWoLA==",
             "license": "ISC",
             "dependencies": {
                 "point-in-polygon": "^1.1.0",
-                "rbush": "^3.0.1",
-                "robust-predicates": "^2.0.4",
-                "tinyqueue": "^2.0.3"
+                "rbush": "^4.0.1",
+                "robust-predicates": "^3.0.2",
+                "tinyqueue": "^3.0.0"
             }
         },
+        "node_modules/concaveman/node_modules/quickselect": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+            "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+            "license": "ISC"
+        },
         "node_modules/concaveman/node_modules/rbush": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-            "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+            "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
             "license": "MIT",
             "dependencies": {
-                "quickselect": "^2.0.0"
+                "quickselect": "^3.0.0"
             }
         },
         "node_modules/confbox": {
@@ -11376,9 +11401,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.43.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-            "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+            "version": "3.44.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+            "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -11387,12 +11412,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.43.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
-            "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
+            "version": "3.44.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
+            "integrity": "sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.25.0"
+                "browserslist": "^4.25.1"
             },
             "funding": {
                 "type": "opencollective",
@@ -11715,9 +11740,9 @@
             "license": "MIT"
         },
         "node_modules/cytoscape": {
-            "version": "3.32.0",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.0.tgz",
-            "integrity": "sha512-5JHBC9n75kz5851jeklCPmZWcg3hUe6sjqJvyk3+hVqFaKcHwHgxsjeN1yLmggoUc6STbtm9/NQyabQehfjvWQ==",
+            "version": "3.32.1",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.1.tgz",
+            "integrity": "sha512-dbeqFTLYEwlFg7UGtcZhCCG/2WayX72zK3Sq323CEX29CY81tYfVhw1MIdduCtpstB0cTOhJswWlM/OEB3Xp+Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10"
@@ -12403,9 +12428,9 @@
             }
         },
         "node_modules/decimal.js": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "dev": true,
             "license": "MIT"
         },
@@ -12868,12 +12893,6 @@
             "dependencies": {
                 "robust-predicates": "^3.0.2"
             }
-        },
-        "node_modules/delaunator/node_modules/robust-predicates": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-            "license": "Unlicense"
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -13432,9 +13451,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.179",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.179.tgz",
-            "integrity": "sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==",
+            "version": "1.5.187",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.187.tgz",
+            "integrity": "sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==",
             "license": "ISC"
         },
         "node_modules/elliptic": {
@@ -13713,9 +13732,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-            "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.7.tgz",
+            "integrity": "sha512-daJB0q2dmTzo90L9NjRaohhRWrCzYxWNFTjEi72/h+p5DcY3yn4MacWfDakHmaBaDzDiuLJsCh0+6LK/iX+c+Q==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -13725,31 +13744,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.5",
-                "@esbuild/android-arm": "0.25.5",
-                "@esbuild/android-arm64": "0.25.5",
-                "@esbuild/android-x64": "0.25.5",
-                "@esbuild/darwin-arm64": "0.25.5",
-                "@esbuild/darwin-x64": "0.25.5",
-                "@esbuild/freebsd-arm64": "0.25.5",
-                "@esbuild/freebsd-x64": "0.25.5",
-                "@esbuild/linux-arm": "0.25.5",
-                "@esbuild/linux-arm64": "0.25.5",
-                "@esbuild/linux-ia32": "0.25.5",
-                "@esbuild/linux-loong64": "0.25.5",
-                "@esbuild/linux-mips64el": "0.25.5",
-                "@esbuild/linux-ppc64": "0.25.5",
-                "@esbuild/linux-riscv64": "0.25.5",
-                "@esbuild/linux-s390x": "0.25.5",
-                "@esbuild/linux-x64": "0.25.5",
-                "@esbuild/netbsd-arm64": "0.25.5",
-                "@esbuild/netbsd-x64": "0.25.5",
-                "@esbuild/openbsd-arm64": "0.25.5",
-                "@esbuild/openbsd-x64": "0.25.5",
-                "@esbuild/sunos-x64": "0.25.5",
-                "@esbuild/win32-arm64": "0.25.5",
-                "@esbuild/win32-ia32": "0.25.5",
-                "@esbuild/win32-x64": "0.25.5"
+                "@esbuild/aix-ppc64": "0.25.7",
+                "@esbuild/android-arm": "0.25.7",
+                "@esbuild/android-arm64": "0.25.7",
+                "@esbuild/android-x64": "0.25.7",
+                "@esbuild/darwin-arm64": "0.25.7",
+                "@esbuild/darwin-x64": "0.25.7",
+                "@esbuild/freebsd-arm64": "0.25.7",
+                "@esbuild/freebsd-x64": "0.25.7",
+                "@esbuild/linux-arm": "0.25.7",
+                "@esbuild/linux-arm64": "0.25.7",
+                "@esbuild/linux-ia32": "0.25.7",
+                "@esbuild/linux-loong64": "0.25.7",
+                "@esbuild/linux-mips64el": "0.25.7",
+                "@esbuild/linux-ppc64": "0.25.7",
+                "@esbuild/linux-riscv64": "0.25.7",
+                "@esbuild/linux-s390x": "0.25.7",
+                "@esbuild/linux-x64": "0.25.7",
+                "@esbuild/netbsd-arm64": "0.25.7",
+                "@esbuild/netbsd-x64": "0.25.7",
+                "@esbuild/openbsd-arm64": "0.25.7",
+                "@esbuild/openbsd-x64": "0.25.7",
+                "@esbuild/openharmony-arm64": "0.25.7",
+                "@esbuild/sunos-x64": "0.25.7",
+                "@esbuild/win32-arm64": "0.25.7",
+                "@esbuild/win32-ia32": "0.25.7",
+                "@esbuild/win32-x64": "0.25.7"
             }
         },
         "node_modules/escalade": {
@@ -13781,9 +13801,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.30.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
-            "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+            "version": "9.31.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+            "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13791,9 +13811,9 @@
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.21.0",
                 "@eslint/config-helpers": "^0.3.0",
-                "@eslint/core": "^0.14.0",
+                "@eslint/core": "^0.15.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.30.1",
+                "@eslint/js": "9.31.0",
                 "@eslint/plugin-kit": "^0.3.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -13842,9 +13862,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "10.1.5",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
-            "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -13858,9 +13878,9 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
-            "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.3.tgz",
+            "integrity": "sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15062,9 +15082,9 @@
             "license": "ISC"
         },
         "node_modules/flow-parser": {
-            "version": "0.274.2",
-            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.274.2.tgz",
-            "integrity": "sha512-kCjoA1h5j+Ttu/9fekY9XzeKPG8SvNtxigiCkezmDIOlcKr+d9LysczrPylEeSYINE3sLlX45W5vT2CroD6sWA==",
+            "version": "0.276.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.276.0.tgz",
+            "integrity": "sha512-rHZzn3I1Hc6L+XCTHe4miH9mEW4+CozvGghVLwE5xHasf2nchq2GJonUowRihuOx6NsJO8pGD+5XdIDH1iLgNg==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -15153,14 +15173,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
-            "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+            "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.35"
             },
             "engines": {
@@ -18127,9 +18148,9 @@
             }
         },
         "node_modules/jsdom/node_modules/form-data": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-            "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19018,6 +19039,12 @@
             "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
             "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/mapbox-gl/node_modules/tinyqueue": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+            "license": "ISC"
         },
         "node_modules/marked": {
             "version": "4.0.12",
@@ -20141,9 +20168,9 @@
             }
         },
         "node_modules/on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -20904,12 +20931,6 @@
                 "robust-predicates": "^3.0.2",
                 "splaytree": "^3.1.0"
             }
-        },
-        "node_modules/polygon-clipping/node_modules/robust-predicates": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-            "license": "Unlicense"
         },
         "node_modules/portfinder": {
             "version": "1.0.37",
@@ -21767,9 +21788,9 @@
             "license": "MIT"
         },
         "node_modules/proj4": {
-            "version": "2.19.5",
-            "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.19.5.tgz",
-            "integrity": "sha512-hFn7GJwUZ1YiAAfSfur7VRgiH0swIZFxJb7UZ7C4E9tbqyozSn+SI9ZxFgFKmUldtY3tVTBvylJhwfD+O3pHQw==",
+            "version": "2.19.7",
+            "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.19.7.tgz",
+            "integrity": "sha512-1YdHp6/MyGh6s0T1zCwGnOUiah/ov/8HJYkHMXHD8YuUTpkbo82OuCSivSs4ydCIODZVico5QVTTXi5yoDkMZA==",
             "license": "MIT",
             "dependencies": {
                 "mgrs": "1.0.0",
@@ -22704,15 +22725,15 @@
             }
         },
         "node_modules/robust-predicates": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
-            "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
-            "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
+            "version": "4.45.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
+            "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.8"
@@ -22725,26 +22746,26 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.44.1",
-                "@rollup/rollup-android-arm64": "4.44.1",
-                "@rollup/rollup-darwin-arm64": "4.44.1",
-                "@rollup/rollup-darwin-x64": "4.44.1",
-                "@rollup/rollup-freebsd-arm64": "4.44.1",
-                "@rollup/rollup-freebsd-x64": "4.44.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.44.1",
-                "@rollup/rollup-linux-arm64-musl": "4.44.1",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.44.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.44.1",
-                "@rollup/rollup-linux-x64-gnu": "4.44.1",
-                "@rollup/rollup-linux-x64-musl": "4.44.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.44.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.44.1",
-                "@rollup/rollup-win32-x64-msvc": "4.44.1",
+                "@rollup/rollup-android-arm-eabi": "4.45.1",
+                "@rollup/rollup-android-arm64": "4.45.1",
+                "@rollup/rollup-darwin-arm64": "4.45.1",
+                "@rollup/rollup-darwin-x64": "4.45.1",
+                "@rollup/rollup-freebsd-arm64": "4.45.1",
+                "@rollup/rollup-freebsd-x64": "4.45.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.45.1",
+                "@rollup/rollup-linux-arm64-musl": "4.45.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.45.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.45.1",
+                "@rollup/rollup-linux-x64-gnu": "4.45.1",
+                "@rollup/rollup-linux-x64-musl": "4.45.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.45.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.45.1",
+                "@rollup/rollup-win32-x64-msvc": "4.45.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -24360,9 +24381,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "16.21.1",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.21.1.tgz",
-            "integrity": "sha512-WCXdXnYK2tpCbebgMF0Bme3YZH/Rh/UXerj75twYo4uLULlcrLwFVdZTvTEF8idFnAcW21YUDJFyKOfaf6xJRw==",
+            "version": "16.22.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.22.0.tgz",
+            "integrity": "sha512-SVEMTdjKNV4ollUrIY9ordZ36zHv2/PHzPjfPMau370MlL2VYXeLgSNMMiEbLGRO8RmD2R8/BVUeF2DfnfkC0w==",
             "dev": true,
             "funding": [
                 {
@@ -24722,13 +24743,13 @@
             "license": "MIT"
         },
         "node_modules/synckit": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
-            "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.10.tgz",
+            "integrity": "sha512-n6Ze5AGOURWdQ9Kg/wqI1//4OBw9V1zuOTj7uQlpAjtpe2bhgPBpmSFXvapbP3KxcRoqo996J28kdT2ly4w9UA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@pkgr/core": "^0.2.4"
+                "@pkgr/core": "^0.3.0"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -25172,9 +25193,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -25194,9 +25215,9 @@
             }
         },
         "node_modules/tinyqueue": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+            "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
             "license": "ISC"
         },
         "node_modules/tinyspy": {
@@ -25717,15 +25738,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.35.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.35.1.tgz",
-            "integrity": "sha512-xslJjFzhOmHYQzSB/QTeASAHbjmxOGEP6Coh93TXmUBFQoJ1VU35UHIDmG06Jd6taf3wqqC1ntBnCMeymy5Ovw==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.37.0.tgz",
+            "integrity": "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.35.1",
-                "@typescript-eslint/parser": "8.35.1",
-                "@typescript-eslint/utils": "8.35.1"
+                "@typescript-eslint/eslint-plugin": "8.37.0",
+                "@typescript-eslint/parser": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -25943,9 +25965,9 @@
             }
         },
         "node_modules/unplugin-utils/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -25992,9 +26014,9 @@
             }
         },
         "node_modules/unplugin/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -27023,9 +27045,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -28210,22 +28232,23 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.99.9",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-            "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+            "version": "5.100.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
+            "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.24.0",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
+                "enhanced-resolve": "^5.17.2",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -28239,7 +28262,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.3.11",
                 "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -28456,33 +28479,17 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/is-wsl": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/webpack-dev-server/node_modules/open": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-            "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
                 "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
+                "wsl-utils": "^0.1.0"
             },
             "engines": {
                 "node": ">=18"
@@ -28851,6 +28858,38 @@
                 }
             }
         },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/xml-name-validator": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -29030,9 +29069,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.71",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
-            "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "django-silk==5.1.0",
     "pre-commit==3.8.0",
     "black==24.4.2",
+    "django-vite",
 ]
 
 [tool.setuptools]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,11 @@
       "vitest/globals"
     ],
     "allowImportingTsExtensions": true,
-  }
+  },
+  "include": [
+    "bcfms/src/**/*.ts",
+    "bcfms/src/**/*.js",
+    "bcfms/src/**/*.tsx",
+    // any other code folders
+  ]
 }

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -27,8 +27,9 @@ module.exports = () => {
         global.SITE_PACKAGES_DIRECTORY = parsedData['SITE_PACKAGES_DIRECTORY'];
         global.ROOT_DIR = parsedData['ROOT_DIR'];
         global.STATIC_URL = parsedData['STATIC_URL'];
-        global.PUBLIC_SERVER_ADDRESS = parsedData['PUBLIC_SERVER_ADDRESS'];
+        global.PUBLIC_SERVER_ADDRESS = parsedData['WEBPACK_SERVER_ADDRESS'];
         global.WEBPACK_DEVELOPMENT_SERVER_PORT = parsedData['WEBPACK_DEVELOPMENT_SERVER_PORT'];
+
 
         // END get data from `.frontend-configuration-settings.json`
         // BEGIN workaround for handling node_modules paths in arches-core vs projects


### PR DESCRIPTION
Also:
- Rebuild package-lock
- Fix webpack build address
- Limit typescript checking locations
- Adds missing django-vite dev dependency

@evgenyg6 - You need to make sure  you have the `WEBPACK_SERVER_ADDRESS=http://localhost/${BCGOV_PROXY_PREFIX}` entry in your .env file, and you should probably recreate your docker container. You can now use the new version of the OAUTH settings.

closes #29 