### PR TITLE
Update bcgov_arches_common dependency to release branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616",
                 "arches-component-lab": "github:archesproject/arches-component-lab#main",
                 "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
-                "bcgov_arches_common": "github:bcgov/bcgov-arches-common#dev/2.0.x_merge_1.3.0",
+                "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",
                 "ckeditor5": "44.2.0",
                 "dayjs": "^1.11.13",
                 "js-cookie": "^3.0.5",
@@ -8407,16 +8407,6 @@
             "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/send": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/serve-index": {
             "version": "1.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@primevue/forms": "^4.3.5",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vue/cli": "^5.0.8",
-                "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616",
+                "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502",
                 "arches-component-lab": "github:archesproject/arches-component-lab#main",
                 "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
                 "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@primevue/forms": "^4.3.5",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/cli": "^5.0.8",
-        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616",
+        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502",
         "arches-component-lab": "github:archesproject/arches-component-lab#main",
         "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
         "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616",
         "arches-component-lab": "github:archesproject/arches-component-lab#main",
         "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
-        "bcgov_arches_common": "github:bcgov/bcgov-arches-common#dev/2.0.x_merge_1.3.0",
+        "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",
         "ckeditor5": "44.2.0",
         "dayjs": "^1.11.13",
         "js-cookie": "^3.0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616",
+    "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616_12502",
     "arches-component-lab @ git+https://github.com/archesproject/arches-component-lab@main",
     "arches-querysets[drf] @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
     "bcgov-arches-common @ git+https://github.com/bcgov/bcgov-arches-common@release/2.0.x",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616",
     "arches-component-lab @ git+https://github.com/archesproject/arches-component-lab@main",
     "arches-querysets[drf] @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
-    "bcgov-arches-common @ git+https://github.com/bcgov/bcgov-arches-common@dev/2.0.x_merge_1.3.0",
+    "bcgov-arches-common @ git+https://github.com/bcgov/bcgov-arches-common@release/2.0.x",
     "django-storages==1.13",
     "python-dotenv",
 ]


### PR DESCRIPTION
Bumps to use latest 8.0.x bcgov-arches-common dependency