### PR TITLE
Point to arches core patch branch w/ multiple fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@primevue/forms": "^4.3.5",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vueuse/core": "^14.2.1",
-                "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502",
+                "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
                 "arches-component-lab": "github:archesproject/arches-component-lab#main",
                 "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
                 "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",
@@ -2896,9 +2896,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-            "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
             "dev": true,
             "funding": [
                 {
@@ -3466,9 +3466,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3560,9 +3560,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3750,9 +3750,9 @@
             "license": "MIT"
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3827,9 +3827,9 @@
             }
         },
         "node_modules/@istanbuljs/schema": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+            "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4606,9 +4606,9 @@
             }
         },
         "node_modules/@maplibre/geojson-vt": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.0.4.tgz",
-            "integrity": "sha512-HYv3POhMRCdhP3UPPATM/hfcy6/WuVIf5FKboH8u/ZuFMTnAIcSVlq5nfOqroLokd925w2QtE7YwquFOIacwVQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+            "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
             "license": "ISC",
             "dependencies": {
                 "kdbush": "^4.0.2"
@@ -7511,12 +7511,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.5.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.18.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -7676,17 +7676,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-            "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+            "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.58.1",
-                "@typescript-eslint/type-utils": "8.58.1",
-                "@typescript-eslint/utils": "8.58.1",
-                "@typescript-eslint/visitor-keys": "8.58.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/type-utils": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -7699,7 +7699,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.58.1",
+                "@typescript-eslint/parser": "^8.58.2",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -7715,16 +7715,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-            "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.58.1",
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/typescript-estree": "8.58.1",
-                "@typescript-eslint/visitor-keys": "8.58.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7740,14 +7740,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-            "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+            "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.58.1",
-                "@typescript-eslint/types": "^8.58.1",
+                "@typescript-eslint/tsconfig-utils": "^8.58.2",
+                "@typescript-eslint/types": "^8.58.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7762,14 +7762,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-            "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+            "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/visitor-keys": "8.58.1"
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7780,9 +7780,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-            "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+            "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7797,15 +7797,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-            "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+            "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/typescript-estree": "8.58.1",
-                "@typescript-eslint/utils": "8.58.1",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -7822,9 +7822,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-            "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+            "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7836,16 +7836,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-            "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+            "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.58.1",
-                "@typescript-eslint/tsconfig-utils": "8.58.1",
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/visitor-keys": "8.58.1",
+                "@typescript-eslint/project-service": "8.58.2",
+                "@typescript-eslint/tsconfig-utils": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -7864,16 +7864,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-            "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.58.1",
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/typescript-estree": "8.58.1"
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7888,13 +7888,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-            "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+            "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/types": "8.58.2",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -8307,9 +8307,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/language-core/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8874,7 +8874,7 @@
         },
         "node_modules/arches": {
             "version": "8.0.10",
-            "resolved": "git+ssh://git@github.com/bcgov/arches.git#33f1975c8a596b1e3d8ef22bee98a94b33953f35",
+            "resolved": "git+ssh://git@github.com/bcgov/arches.git#36c6cffc93a6d58f5f02524d1e2de4222445b8c8",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
@@ -8954,15 +8954,6 @@
                 "quill": "2.0.3"
             }
         },
-        "node_modules/arches-component-lab/node_modules/@primeuix/themes": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.3.tgz",
-            "integrity": "sha512-GLAU2h6lhgln2w10EQalUQlgwbgQ0xZoIOLMNGfIvqU4O09L282P7rwKCKQksvAGAFt1GoO/Q1NgBSxnttr7iA==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2"
-            }
-        },
         "node_modules/arches-component-lab/node_modules/@primevue/core": {
             "version": "4.3.9",
             "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.9.tgz",
@@ -8991,142 +8982,6 @@
             },
             "engines": {
                 "node": ">=12.11.0"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/@primevue/icons": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.3.7.tgz",
-            "integrity": "sha512-CKiOeiJzNSbELwbQdrgWHgmfcAmjNQXqRZtBGb8sUPrB8hjWf9lYMBAbcAuqJbyLFFcC0lFiB80CfBR07FNSHw==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/utils": "^0.6.1",
-                "@primevue/core": "4.3.7"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/@primevue/icons/node_modules/@primevue/core": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.7.tgz",
-            "integrity": "sha512-rYmEZTKs/C2Re+xFluY9R02+n4TcyJshooPPOG6zc23v/bmhrfcqCiS5gNiuXF/lYoOh4y8VTcHF6eZCZW724Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2",
-                "@primeuix/utils": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/arches": {
-            "version": "8.0.11",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#67893fdda6da82ce3343b0321b280203900bc7a7",
-            "license": "AGPL-3.0-only",
-            "dependencies": {
-                "@babel/runtime": "^7.17.2",
-                "@mapbox/geojson-extent": "1.0.1",
-                "@mapbox/geojsonhint": "3.3.0",
-                "@mapbox/mapbox-gl-draw": "1.4.3",
-                "@mapbox/mapbox-gl-geocoder": "4.7.4",
-                "@primeuix/themes": "1.2.3",
-                "@tmcw/togeojson": "^4.3.0",
-                "@turf/turf": "^6.5.0",
-                "backbone": "1.3.3",
-                "bootstrap": "3.4.1",
-                "bootstrap-colorpicker": "^2.5.3",
-                "chosen-js": "1.8.7",
-                "ckeditor4": "ckeditor/ckeditor4-releases#full/4.22.1",
-                "codemirror": "^5.65.6",
-                "core-js": "^3.21.1",
-                "cross-env": "^7.0.3",
-                "cross-fetch": "^3.1.5",
-                "cytoscape": "^3.18.2",
-                "cytoscape-cola": "^2.4.0",
-                "d3": "^7.9.0",
-                "datatables.net": "~1.12.1",
-                "datatables.net-bs": "~1.13.11",
-                "datatables.net-buttons": "~2.4.3",
-                "datatables.net-buttons-bs": "~2.4.3",
-                "datatables.net-responsive": "~2.5.1",
-                "datatables.net-responsive-bs": "~2.5.1",
-                "dom4": "^2.0.1",
-                "dropzone": "5.7.0",
-                "eonasdan-bootstrap-datetimepicker": "~4.17.49",
-                "font-awesome": "~4.6.3",
-                "ionicons": "~2.0.1",
-                "jqtree": "1.3.4",
-                "jquery": "^3.6.2",
-                "jquery-migrate": "~3.4.1",
-                "jquery-validation": "1.19.5",
-                "jqueryui": "1.11.1",
-                "js-cookie": "2.1.1",
-                "knockout": "3.5.0",
-                "knockout-mapping": "~2.6.0",
-                "knockstrap": "1.3.2",
-                "latlon-geohash": "1.1.0",
-                "leaflet": "1.6.0",
-                "leaflet-draw": "^1.0.4",
-                "leaflet-iiif": "^3.0.0",
-                "leaflet.fullscreen": "^1.6.0",
-                "lt-themify-icons": "^1.1.0",
-                "mapbox-gl": "1.13.3",
-                "metismenu": "2.7.2",
-                "moment": "^2.29.4",
-                "normalize.css": "^8.0.1",
-                "nouislider": "11.0.3",
-                "numeral": "^2.0.6",
-                "primeicons": "^7.0.0",
-                "primevue": "4.3.7",
-                "proj4": "^2.3.15",
-                "select-woo": "jadu/selectWoo",
-                "shpjs": "~6.1.0",
-                "underscore": "^1.13.6",
-                "uuidjs": "^3.3.0",
-                "vue": "^3.5.20",
-                "vue3-gettext": "^3.0.0-beta.6",
-                "webpack-bundle-tracker": "^3.1.0"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/js-cookie": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.1.tgz",
-            "integrity": "sha512-BYjLHmXr/YFnH1x+wmK5qSSsag7bKRF7JDp6BRBsSjIXOnZoI6Y+JrmlCqN99/9MQq/Dim/cc949wwkEJCuPnQ==",
-            "license": "MIT"
-        },
-        "node_modules/arches-component-lab/node_modules/primevue": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.3.7.tgz",
-            "integrity": "sha512-yyknh2kFjSGwRyxqmUUWy/pY4FK1vxoonGH3eQdtd8k/sGl5JpSQ2f0tXpR79lV6dcGf3FZPL1B5JNR11zJfmg==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2",
-                "@primeuix/styles": "^1.2.3",
-                "@primeuix/utils": "^0.6.1",
-                "@primevue/core": "4.3.7",
-                "@primevue/icons": "4.3.7"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/primevue/node_modules/@primevue/core": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.7.tgz",
-            "integrity": "sha512-rYmEZTKs/C2Re+xFluY9R02+n4TcyJshooPPOG6zc23v/bmhrfcqCiS5gNiuXF/lYoOh4y8VTcHF6eZCZW724Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2",
-                "@primeuix/utils": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
             }
         },
         "node_modules/arches-dev-dependencies": {
@@ -9242,323 +9097,6 @@
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "arches": "archesproject/arches#stable/8.1.0"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@babel/runtime": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-            "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@primeuix/themes": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.2.3.tgz",
-            "integrity": "sha512-GLAU2h6lhgln2w10EQalUQlgwbgQ0xZoIOLMNGfIvqU4O09L282P7rwKCKQksvAGAFt1GoO/Q1NgBSxnttr7iA==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@primevue/core": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.7.tgz",
-            "integrity": "sha512-rYmEZTKs/C2Re+xFluY9R02+n4TcyJshooPPOG6zc23v/bmhrfcqCiS5gNiuXF/lYoOh4y8VTcHF6eZCZW724Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2",
-                "@primeuix/utils": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@primevue/icons": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.3.7.tgz",
-            "integrity": "sha512-CKiOeiJzNSbELwbQdrgWHgmfcAmjNQXqRZtBGb8sUPrB8hjWf9lYMBAbcAuqJbyLFFcC0lFiB80CfBR07FNSHw==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/utils": "^0.6.1",
-                "@primevue/core": "4.3.7"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/compiler-core": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.20.tgz",
-            "integrity": "sha512-8TWXUyiqFd3GmP4JTX9hbiTFRwYHgVL/vr3cqhr4YQ258+9FADwvj7golk2sWNGHR67QgmCZ8gz80nQcMokhwg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.28.3",
-                "@vue/shared": "3.5.20",
-                "entities": "^4.5.0",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/compiler-dom": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.20.tgz",
-            "integrity": "sha512-whB44M59XKjqUEYOMPYU0ijUV0G+4fdrHVKDe32abNdX/kJe1NUEMqsi4cwzXa9kyM9w5S8WqFsrfo1ogtBZGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.20",
-                "@vue/shared": "3.5.20"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.20.tgz",
-            "integrity": "sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.28.3",
-                "@vue/compiler-core": "3.5.20",
-                "@vue/compiler-dom": "3.5.20",
-                "@vue/compiler-ssr": "3.5.20",
-                "@vue/shared": "3.5.20",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.17",
-                "postcss": "^8.5.6",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.20.tgz",
-            "integrity": "sha512-RSl5XAMc5YFUXpDQi+UQDdVjH9FnEpLDHIALg5J0ITHxkEzJ8uQLlo7CIbjPYqmZtt6w0TsIPbo1izYXwDG7JA==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.20",
-                "@vue/shared": "3.5.20"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/reactivity": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.20.tgz",
-            "integrity": "sha512-hS8l8x4cl1fmZpSQX/NXlqWKARqEsNmfkwOIYqtR2F616NGfsLUm0G6FQBK6uDKUCVyi1YOL8Xmt/RkZcd/jYQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.20"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/runtime-core": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.20.tgz",
-            "integrity": "sha512-vyQRiH5uSZlOa+4I/t4Qw/SsD/gbth0SW2J7oMeVlMFMAmsG1rwDD6ok0VMmjXY3eI0iHNSSOBilEDW98PLRKw==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.20",
-                "@vue/shared": "3.5.20"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/runtime-dom": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.20.tgz",
-            "integrity": "sha512-KBHzPld/Djw3im0CQ7tGCpgRedryIn4CcAl047EhFTCCPT2xFf4e8j6WeKLgEEoqPSl9TYqShc3Q6tpWpz/Xgw==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.20",
-                "@vue/runtime-core": "3.5.20",
-                "@vue/shared": "3.5.20",
-                "csstype": "^3.1.3"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/server-renderer": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.20.tgz",
-            "integrity": "sha512-HthAS0lZJDH21HFJBVNTtx+ULcIbJQRpjSVomVjfyPkFSpCwvsPTA+jIzOaUm3Hrqx36ozBHePztQFg6pj5aKg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.20",
-                "@vue/shared": "3.5.20"
-            },
-            "peerDependencies": {
-                "vue": "3.5.20"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/@vue/shared": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.20.tgz",
-            "integrity": "sha512-SoRGP596KU/ig6TfgkCMbXkr4YJ91n/QSdMuqeP5r3hVIYA3CPHUBCc7Skak0EAKV+5lL4KyIh61VA/pK1CIAA==",
-            "license": "MIT"
-        },
-        "node_modules/arches-querysets/node_modules/arches": {
-            "version": "8.1.0",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#2127517966462ea024ffb000b2e1fd46bf66d6dd",
-            "license": "AGPL-3.0-only",
-            "dependencies": {
-                "@babel/runtime": "7.28.3",
-                "@mapbox/geojson-extent": "1.0.1",
-                "@mapbox/geojsonhint": "3.3.0",
-                "@mapbox/mapbox-gl-draw": "1.4.3",
-                "@mapbox/mapbox-gl-geocoder": "4.7.4",
-                "@primeuix/themes": "1.2.3",
-                "@tmcw/togeojson": "4.7.0",
-                "@turf/turf": "6.5.0",
-                "backbone": "1.3.3",
-                "bootstrap": "3.4.1",
-                "bootstrap-colorpicker": "2.5.3",
-                "chosen-js": "1.8.7",
-                "ckeditor4": "ckeditor/ckeditor4-releases#full/4.22.1",
-                "codemirror": "5.65.20",
-                "core-js": "3.45.1",
-                "cross-env": "7.0.3",
-                "cross-fetch": "3.2.0",
-                "cytoscape": "3.33.1",
-                "cytoscape-cola": "2.5.1",
-                "d3": "7.9.0",
-                "datatables.net": "1.12.1",
-                "datatables.net-bs": "1.13.11",
-                "datatables.net-buttons": "2.4.3",
-                "datatables.net-buttons-bs": "2.4.3",
-                "datatables.net-responsive": "2.5.1",
-                "datatables.net-responsive-bs": "2.5.1",
-                "dom4": "2.1.6",
-                "dropzone": "5.7.0",
-                "eonasdan-bootstrap-datetimepicker": "4.17.49",
-                "font-awesome": "4.6.3",
-                "ionicons": "2.0.1",
-                "jqtree": "1.3.4",
-                "jquery": "3.7.1",
-                "jquery-migrate": "3.4.1",
-                "jquery-validation": "1.19.5",
-                "jqueryui": "1.11.1",
-                "js-cookie": "3.0.5",
-                "knockout": "3.5.0",
-                "knockout-mapping": "~2.6.0",
-                "knockstrap": "1.3.2",
-                "latlon-geohash": "1.1.0",
-                "leaflet": "1.6.0",
-                "leaflet-draw": "1.0.4",
-                "leaflet-iiif": "3.0.0",
-                "leaflet.fullscreen": "1.6.0",
-                "lt-themify-icons": "1.1.0",
-                "mapbox-gl": "1.13.3",
-                "metismenu": "2.7.2",
-                "moment": "2.30.1",
-                "normalize.css": "8.0.1",
-                "nouislider": "11.0.3",
-                "numeral": "2.0.6",
-                "primeicons": "7.0.0",
-                "primevue": "4.3.7",
-                "proj4": "2.19.10",
-                "select-woo": "jadu/selectWoo",
-                "shpjs": "6.1.0",
-                "underscore": "^1.13.6",
-                "uuidjs": "3.6.2",
-                "vue": "3.5.20",
-                "vue3-gettext": "3.0.0-beta.6",
-                "webpack-bundle-tracker": "3.2.0"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/codemirror": {
-            "version": "5.65.20",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
-            "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
-            "license": "MIT"
-        },
-        "node_modules/arches-querysets/node_modules/core-js": {
-            "version": "3.45.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
-            "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/cytoscape": {
-            "version": "3.33.1",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-            "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/primevue": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.3.7.tgz",
-            "integrity": "sha512-yyknh2kFjSGwRyxqmUUWy/pY4FK1vxoonGH3eQdtd8k/sGl5JpSQ2f0tXpR79lV6dcGf3FZPL1B5JNR11zJfmg==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2",
-                "@primeuix/styles": "^1.2.3",
-                "@primeuix/utils": "^0.6.1",
-                "@primevue/core": "4.3.7",
-                "@primevue/icons": "4.3.7"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/proj4": {
-            "version": "2.19.10",
-            "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.19.10.tgz",
-            "integrity": "sha512-uL6/C6kA8+ncJAEDmUeV8PmNJcTlRLDZZa4/87CzRpb8My4p+Ame4LhC4G3H/77z2icVqcu3nNL9h5buSdnY+g==",
-            "license": "MIT",
-            "dependencies": {
-                "mgrs": "1.0.0",
-                "wkt-parser": "^1.5.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ahocevar"
-            }
-        },
-        "node_modules/arches-querysets/node_modules/vue": {
-            "version": "3.5.20",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.20.tgz",
-            "integrity": "sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.20",
-                "@vue/compiler-sfc": "3.5.20",
-                "@vue/runtime-dom": "3.5.20",
-                "@vue/server-renderer": "3.5.20",
-                "@vue/shared": "3.5.20"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/arches-querysets/node_modules/webpack-bundle-tracker": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-3.2.0.tgz",
-            "integrity": "sha512-/CV+Mre7jC+lSTjF7nYv36FpdwIQR15URKGHpLmdgGxxdYFQ858MV13J0qqR7Rn3wke3O41yX0tNntPv3uo1QA==",
-            "license": "MIT",
-            "dependencies": {
-                "lodash.assign": "^4.2.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.foreach": "^4.5.0",
-                "lodash.frompairs": "^4.0.1",
-                "lodash.topairs": "^4.3.0"
             }
         },
         "node_modules/arches/node_modules/@primeuix/themes": {
@@ -9948,9 +9486,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.17",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
-            "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+            "version": "2.10.18",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+            "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -10099,9 +9637,9 @@
             }
         },
         "node_modules/bcgov_arches_common/node_modules/lru-cache": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -12590,9 +12128,9 @@
             "license": "MIT"
         },
         "node_modules/del/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12986,9 +12524,9 @@
             "license": "MIT"
         },
         "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13029,9 +12567,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.334",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-            "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+            "version": "1.5.336",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+            "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -13614,9 +13152,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14230,9 +13768,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -14566,9 +14104,9 @@
             "license": "MIT"
         },
         "node_modules/gettext-extractor/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -14690,9 +14228,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -17209,12 +16747,6 @@
             "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "license": "MIT"
         },
-        "node_modules/lodash.assign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-            "license": "MIT"
-        },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -17233,24 +16765,6 @@
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "license": "MIT"
         },
-        "node_modules/lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-            "license": "MIT"
-        },
-        "node_modules/lodash.foreach": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-            "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
-            "license": "MIT"
-        },
-        "node_modules/lodash.frompairs": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
-            "integrity": "sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw==",
-            "license": "MIT"
-        },
         "node_modules/lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -17263,12 +16777,6 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.topairs": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
-            "integrity": "sha512-qrRMbykBSEGdOgQLJJqVSdPWMD7Q+GJJ5jMRfQYb+LTLsw3tYVIabnCzRqTJb2WTo17PG5gNzXuFaZgYH/9SAQ==",
             "license": "MIT"
         },
         "node_modules/lodash.truncate": {
@@ -17510,9 +17018,9 @@
             "license": "ISC"
         },
         "node_modules/maplibre-gl": {
-            "version": "5.22.0",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.22.0.tgz",
-            "integrity": "sha512-nc8YA+YSEioMZg5W0cb6Cf3wQ8aJge66dsttyBgpOArOnlmFJO1Kc5G32kYVPeUYhLpBja83T99uanmJvYAIyQ==",
+            "version": "5.23.0",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.23.0.tgz",
+            "integrity": "sha512-aou8YBNFS8uVtDWFWt0W/6oorfl18wt+oIA8fnXk1kivjkbtXi9gGrQvflTpwrR3hG13aWdIdbYWeN0NFMV7ag==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -17521,7 +17029,7 @@
                 "@mapbox/unitbezier": "^0.0.1",
                 "@mapbox/vector-tile": "^2.0.4",
                 "@mapbox/whoots-js": "^3.1.0",
-                "@maplibre/geojson-vt": "^6.0.4",
+                "@maplibre/geojson-vt": "^6.1.0",
                 "@maplibre/maplibre-gl-style-spec": "^24.8.1",
                 "@maplibre/mlt": "^1.1.8",
                 "@maplibre/vt-pbf": "^4.3.0",
@@ -19428,9 +18936,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+            "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -19507,9 +19015,9 @@
             }
         },
         "node_modules/prettier-eslint/node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19676,9 +19184,9 @@
             "license": "MIT"
         },
         "node_modules/prettier-eslint/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19773,9 +19281,9 @@
             }
         },
         "node_modules/prettier-eslint/node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -20831,11 +20339,12 @@
             "license": "MIT"
         },
         "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "license": "MIT",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
@@ -23567,16 +23076,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-            "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+            "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.58.1",
-                "@typescript-eslint/parser": "8.58.1",
-                "@typescript-eslint/typescript-estree": "8.58.1",
-                "@typescript-eslint/utils": "8.58.1"
+                "@typescript-eslint/eslint-plugin": "8.58.2",
+                "@typescript-eslint/parser": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -23638,9 +23147,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "license": "MIT"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -24700,9 +24209,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.106.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
-            "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
+            "version": "5.106.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
+            "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@primevue/forms": "^4.3.5",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vueuse/core": "^14.2.1",
-                "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
+                "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697_12610",
                 "arches-component-lab": "github:archesproject/arches-component-lab#main",
                 "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
                 "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",
@@ -38,7 +38,7 @@
                 "@typescript-eslint/parser": "^8.24.1",
                 "@vue/eslint-config-prettier": "^10.2.0",
                 "@vue/eslint-config-typescript": "^14.4.0",
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/8.0.8",
+                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/8.0.10",
                 "eslint": "^9.29.0",
                 "eslint-plugin-vue": "^9.32.0",
                 "globals": "^16.0.0",
@@ -8874,7 +8874,7 @@
         },
         "node_modules/arches": {
             "version": "8.0.10",
-            "resolved": "git+ssh://git@github.com/bcgov/arches.git#36c6cffc93a6d58f5f02524d1e2de4222445b8c8",
+            "resolved": "git+ssh://git@github.com/bcgov/arches.git#cf01b97f7d18b489196327047eac035988bf0a5c",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
@@ -8985,8 +8985,8 @@
             }
         },
         "node_modules/arches-dev-dependencies": {
-            "version": "8.0.8",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#144a6b2a2a4c7b7dee6cf25b2b9957cf1133b648",
+            "version": "8.0.10",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#3c87cd92c98c69f25f64694cb6262c54844fa437",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.24.4",
@@ -9486,9 +9486,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.18",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-            "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+            "version": "2.10.19",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+            "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -10294,9 +10294,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001787",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-            "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+            "version": "1.0.30001788",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+            "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
             "dev": true,
             "funding": [
                 {
@@ -12431,9 +12431,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "vitest": "vitest --run --coverage"
     },
     "overrides": {
-        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
+        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697_12610",
         "moment-timezone": "^0.5.45",
         "nomnom": "npm:@gerhobbelt/nomnom",
         "rimraf": "^5.0.7",
@@ -38,7 +38,7 @@
         "@typescript-eslint/parser": "^8.24.1",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.4.0",
-        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/8.0.8",
+        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/8.0.10",
         "eslint": "^9.29.0",
         "eslint-plugin-vue": "^9.32.0",
         "globals": "^16.0.0",
@@ -58,7 +58,7 @@
         "@primevue/forms": "^4.3.5",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vueuse/core": "^14.2.1",
-        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
+        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697_12610",
         "arches-component-lab": "github:archesproject/arches-component-lab#main",
         "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
         "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "vitest": "vitest --run --coverage"
     },
     "overrides": {
+        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
         "moment-timezone": "^0.5.45",
         "nomnom": "npm:@gerhobbelt/nomnom",
         "rimraf": "^5.0.7",
@@ -57,7 +58,7 @@
         "@primevue/forms": "^4.3.5",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vueuse/core": "^14.2.1",
-        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502",
+        "arches": "github:bcgov/arches#stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
         "arches-component-lab": "github:archesproject/arches-component-lab#main",
         "arches-querysets": "github:archesproject/arches-querysets#dev/1.1.x",
         "bcgov_arches_common": "github:bcgov/bcgov-arches-common#release/2.0.x",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616_12502",
+    "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
     "arches-component-lab @ git+https://github.com/archesproject/arches-component-lab@main",
     "arches-querysets[drf] @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
     "bcgov-arches-common @ git+https://github.com/bcgov/bcgov-arches-common@release/2.0.x",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616_12502_12697",
+    "arches @ git+https://github.com/bcgov/arches@stable/8.0.10_bcgov_12578_12377_12616_12502_12697_12610",
     "arches-component-lab @ git+https://github.com/archesproject/arches-component-lab@main",
     "arches-querysets[drf] @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
     "bcgov-arches-common @ git+https://github.com/bcgov/bcgov-arches-common@release/2.0.x",


### PR DESCRIPTION
closes #88: Use patched arches core version of 8.0.10 to fix relationship not being deleted when resource removed from tile node
closes #154: Use patched arches core version of 8.0.10 to fix css rules bleeding into unintended parts of the page.